### PR TITLE
fixed get_active_order endpoint

### DIFF
--- a/pybit/__init__.py
+++ b/pybit/__init__.py
@@ -540,7 +540,7 @@ class HTTP:
             suffix = endpoint
         else:
             if self.spot is True or kwargs.get('spot', '') is True:
-                suffix = '/spot/v1/history-orders'
+                suffix = '/spot/v1/order'
             elif kwargs.get('symbol', '').endswith('USDT'):
                 suffix = '/private/linear/order/list'
             elif kwargs.get('symbol', '')[-2:].isdigit():

--- a/pybit/spot.py
+++ b/pybit/spot.py
@@ -201,7 +201,7 @@ class HTTP(_HTTPManager):
         :returns: Request results as dictionary.
         """
 
-        suffix = "/spot/v1/history-orders"
+        suffix = "/spot/v1/order"
 
         return self._submit_request(
             method="GET",


### PR DESCRIPTION
Fixes #15 

The general HTTP class allows passing in an endpoint to override the suffix. However, spot.HTTP doesn't. For that method, the endpoint is completely wrong. This PR sets the default for both methods, in the case of a spot request to `'/spot/v1/order'` instead of `'/spot/v1/history-orders'`