### PR TITLE
Use position_idx param when closing position

### DIFF
--- a/pybit/usdt_perpetual.py
+++ b/pybit/usdt_perpetual.py
@@ -680,7 +680,8 @@ class HTTP(_FuturesHTTPManager):
                 "qty": p["size"],
                 "time_in_force": "ImmediateOrCancel",
                 "reduce_only": True,
-                "close_on_trigger": True
+                "close_on_trigger": True,
+                "position_idx": p["position_idx"]
             } for p in (r if isinstance(r, list) else [r]) if p["size"] > 0
         ]
 


### PR DESCRIPTION
### Description:
Updated `usdt_perpetual.py` interface, close_position method to include position mode retrieved from previous position request. This fixes issue when you have a contract set in isolated mode and try to close it using the `close_position` method.

### Steps to reproduce:
* Set contract to a isolated mode
* Open a position
* Try to close it with `close_position`

pybit.exceptions.InvalidRequestError: Position idx not match position mode (ErrCode: 130001) (ErrTime: 16:00:19).