### PR TITLE
redesign reconnection logic to avoid spam reconnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.2rc1] - 2022-06-10
+### Added
+- `is_connected()` function to `WebSocket` class so that you can check if your WSS connection is alive
+
+### Fixed
+- Bug where, upon WSS disconnection, pybit rapidly tries to re-establish the connection, which results in being banned by the CDN for malicious activity
+
 ## [2.2.2rc0] - 2022-06-10
 ### Modified
 - Improved HTTP error handling and logging to ease troubleshooting

--- a/pybit/__init__.py
+++ b/pybit/__init__.py
@@ -33,7 +33,7 @@ except ImportError:
     from json.decoder import JSONDecodeError
 
 # Versioning.
-VERSION = '2.2.2rc0'
+VERSION = '2.2.2rc1'
 
 
 class HTTP:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='pybit',
-    version='2.2.2rc0',
+    version='2.2.2rc1',
     description='Python3 Bybit HTTP/WebSocket API Connector', 
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
- Understanding the logic flaw in why this bug occurred:
  - WSS disconnection, `_on_error()` is called; 
  - which calls `_connect()` to reconnect;
  - which will try to reconnect 10 times;
  - but each time the reconnection is attempted which fails, an error occurs;
  - which calls `_on_error()` (and so the cycle repeats)
- Fixed by preventing calls to `_connect()` whilst a connection is being attempted


