### PR TITLE
Fix wrong endpoints and remove duplicates in "account_asset"

### DIFF
--- a/pybit/account_asset.py
+++ b/pybit/account_asset.py
@@ -206,52 +206,8 @@ class HTTP(_HTTPManager):
 
         """
         return self._submit_request(
-            method="POST",
-            path=self.endpoint + "/asset/v1/private/transferable-subs/save",
-            query=kwargs,
-            auth=True
-        )
-
-    def enable_universal_transfer(self, **kwargs):
-        """
-        :param kwargs: See
-            https://bybit-exchange.github.io/docs/account_asset/#t-deposit_addr_info.
-        :returns: Request results as dictionary.
-
-        """
-        return self._submit_request(
-            method="POST",
-            path=self.endpoint + "/asset/v1/private/transferable-subs/save",
-            query=kwargs,
-            auth=True
-        )
-
-    def create_universal_transfer(self, **kwargs):
-        """
-        :param kwargs: See
-            https://bybit-exchange.github.io/docs/account_asset/#t-deposit_addr_info.
-        :returns: Request results as dictionary.
-
-        """
-        return self._submit_request(
-            method="POST",
-            path=self.endpoint + "/asset/v1/private/universal/transfer",
-            query=kwargs,
-            auth=True
-        )
-
-    def query_universal_transfer_list(self, **kwargs):
-        """
-        Rules: Subaccount can not deposit
-
-        :param kwargs: See
-            https://bybit-exchange.github.io/docs/account_asset/#t-deposit_addr_info.
-        :returns: Request results as dictionary.
-
-        """
-        return self._submit_request(
-            method="POST",
-            path=self.endpoint + "/asset/v1/private/transferable-subs/save",
+            method="GET",
+            path=self.endpoint + "/asset/v1/private/deposit/address",
             query=kwargs,
             auth=True
         )
@@ -286,6 +242,8 @@ class HTTP(_HTTPManager):
 
     def query_universal_transfer_list(self, **kwargs):
         """
+        Rules: Subaccount can not deposit
+
         :param kwargs: See
             https://bybit-exchange.github.io/docs/account_asset/#t-queryuniversetransferlist.
         :returns: Request results as dictionary.


### PR DESCRIPTION
In `account_asset`:
- Duplicate of `enable_universal_transfer`, `create_universal_transfer` and `query_universal_transfer_list` are removed.
- Wrong endpoint of `query_deposit_address` is fixed.

Refs #66 (Discovered after creating the PR).