### PR TITLE
fix legacy submodule not getting packaged by setup.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+- Ensured that `legacy` submodule is packaged by `setup.py`
+
+
 ## [5.1.1] - 2023-04-06
 ### Added
 - HTTP endpoints to the `copy_trading` module

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         "Programming Language :: Python :: 3.10",
     ],
     keywords="bybit api connector",
-    packages=["pybit"],
+    packages=["pybit", "pybit.legacy"],
     python_requires=">=3.6",
     install_requires=[
         "requests",


### PR DESCRIPTION
Fixes the problem where the legacy directory, which includes modules like copy_trading, was not getting packaged and therefore not available in the PyPI installed version of pybit