### PR TITLE
Add rate limit reset timestamp and response headers in Error

### DIFF
--- a/pybit/_http_manager.py
+++ b/pybit/_http_manager.py
@@ -185,6 +185,7 @@ class _V5HTTPManager:
                     message="Bad Request. Retries exceeded maximum.",
                     status_code=400,
                     time=dt.utcnow().strftime("%H:%M:%S"),
+                    resp_headers=None,
                 )
 
             retries_remaining = f"{retries_attempted} retries remain."
@@ -269,6 +270,7 @@ class _V5HTTPManager:
                         message=error_msg,
                         status_code=s.status_code,
                         time=dt.utcnow().strftime("%H:%M:%S"),
+                        resp_headers=s.headers,
                         rate_limit_reset_timestamp=rate_limit_reset_timestamp and int(rate_limit_reset_timestamp),
                     )
                 else:
@@ -279,6 +281,7 @@ class _V5HTTPManager:
                         message=error_msg,
                         status_code=s.status_code,
                         time=dt.utcnow().strftime("%H:%M:%S"),
+                        resp_headers=s.headers,
                     )
 
             # Convert response to dictionary, or raise if requests error.
@@ -298,6 +301,7 @@ class _V5HTTPManager:
                         message="Conflict. Could not decode JSON.",
                         status_code=409,
                         time=dt.utcnow().strftime("%H:%M:%S"),
+                        resp_headers=s.headers,
                     )
 
             ret_code = "retCode"

--- a/pybit/_http_manager.py
+++ b/pybit/_http_manager.py
@@ -355,6 +355,7 @@ class _V5HTTPManager:
                         message=s_json[ret_msg],
                         status_code=s_json[ret_code],
                         time=dt.utcnow().strftime("%H:%M:%S"),
+                        resp_headers=s.headers,
                     )
             else:
                 if self.record_request_time:

--- a/pybit/exceptions.py
+++ b/pybit/exceptions.py
@@ -21,11 +21,12 @@ class FailedRequestError(Exception):
         time -- The time of the error.
     """
 
-    def __init__(self, request, message, status_code, time):
+    def __init__(self, request, message, status_code, time, resp_headers):
         self.request = request
         self.message = message
         self.status_code = status_code
         self.time = time
+        self.resp_headers = resp_headers
         super().__init__(
             f"{message.capitalize()} (ErrCode: {status_code}) (ErrTime: {time})"
             f".\nRequest → {request}."

--- a/pybit/exceptions.py
+++ b/pybit/exceptions.py
@@ -44,11 +44,12 @@ class InvalidRequestError(Exception):
         time -- The time of the error.
     """
 
-    def __init__(self, request, message, status_code, time):
+    def __init__(self, request, message, status_code, time, resp_headers):
         self.request = request
         self.message = message
         self.status_code = status_code
         self.time = time
+        self.resp_headers = resp_headers
         super().__init__(
             f"{message} (ErrCode: {status_code}) (ErrTime: {time})"
             f".\nRequest → {request}."

--- a/pybit/exceptions.py
+++ b/pybit/exceptions.py
@@ -52,3 +52,14 @@ class InvalidRequestError(Exception):
             f"{message} (ErrCode: {status_code}) (ErrTime: {time})"
             f".\nRequest → {request}."
         )
+
+
+class BreachedRateLimitError(FailedRequestError):
+    """
+    Exception raised for HTTP 403 error when breached rate limit
+    """
+
+    def __init__(self, rate_limit_reset_timestamp, **kwargs):
+        super().__init__(**kwargs)
+
+        self.rate_limit_reset_timestamp = rate_limit_reset_timestamp


### PR DESCRIPTION
Return "rate_limit_reset_timestamp" on 403 breached IP rate limit.
Return response headers on FailedRequestError.