### PR TITLE
Fix handling api rate limit hit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 - Remove unnecessary `print` statements in two methods
-- Add extra logging when passing `log_requests=True`
-
+- Add extra logging (log response headers) when passing `log_requests=True`
+- Fix API rate limit handling
+- Add response headers to exceptions
+- Add argument `return_response_headers` to allow returning the response headers to the user
 
 ## [5.2.0] - 2023-04-18
 ### Added

--- a/pybit/_http_manager.py
+++ b/pybit/_http_manager.py
@@ -186,6 +186,7 @@ class _V5HTTPManager:
                     message="Bad Request. Retries exceeded maximum.",
                     status_code=400,
                     time=dt.utcnow().strftime("%H:%M:%S"),
+                    resp_headers=None,
                 )
 
             retries_remaining = f"{retries_attempted} retries remain."
@@ -271,6 +272,7 @@ class _V5HTTPManager:
                     message=error_msg,
                     status_code=s.status_code,
                     time=dt.utcnow().strftime("%H:%M:%S"),
+                    resp_headers=s.headers,
                 )
 
             # Convert response to dictionary, or raise if requests error.
@@ -290,6 +292,7 @@ class _V5HTTPManager:
                         message="Conflict. Could not decode JSON.",
                         status_code=409,
                         time=dt.utcnow().strftime("%H:%M:%S"),
+                        resp_headers=s.headers,
                     )
 
             ret_code = "retCode"
@@ -343,6 +346,7 @@ class _V5HTTPManager:
                         message=s_json[ret_msg],
                         status_code=s_json[ret_code],
                         time=dt.utcnow().strftime("%H:%M:%S"),
+                        resp_headers=s.headers,
                     )
             else:
                 if self.log_requests:

--- a/pybit/_http_manager.py
+++ b/pybit/_http_manager.py
@@ -304,7 +304,7 @@ class _V5HTTPManager:
                 error_msg = f"{s_json[ret_msg]} (ErrCode: {s_json[ret_code]})"
 
                 # Set default retry delay.
-                err_delay = self.retry_delay
+                delay_time = self.retry_delay
 
                 # Retry non-fatal whitelisted error requests.
                 if s_json[ret_code] in self.retry_codes:
@@ -313,28 +313,27 @@ class _V5HTTPManager:
                         error_msg += ". Added 2.5 seconds to recv_window"
                         recv_window += 2500
 
-                    # 10006, ratelimit error; wait until rate_limit_reset_ms
-                    # and retry.
+                    # 10006, rate limit error; wait until
+                    # X-Bapi-Limit-Reset-Timestamp and retry.
                     elif s_json[ret_code] == 10006:
                         self.logger.error(
-                            f"{error_msg}. Ratelimited on current request. "
+                            f"{error_msg}. Hit the API rate limit. "
                             f"Sleeping, then trying again. Request: {path}"
                         )
 
-                        # Calculate how long we need to wait.
-                        limit_reset = s_json["rate_limit_reset_ms"] / 1000
-                        reset_str = time.strftime(
-                            "%X", time.localtime(limit_reset)
-                        )
-                        err_delay = int(limit_reset) - int(time.time())
+                        # Calculate how long we need to wait in milliseconds.
+                        limit_reset_time = int(s.headers["X-Bapi-Limit-Reset-Timestamp"])
+                        limit_reset_str = dt.fromtimestamp(limit_reset_time / 10**3).strftime(
+                            "%H:%M:%S.%f")[:-3]
+                        delay_time = (int(limit_reset_time) - _helpers.generate_timestamp()) / 10**3
                         error_msg = (
-                            f"Ratelimit will reset at {reset_str}. "
-                            f"Sleeping for {err_delay} seconds"
+                            f"API rate limit will reset at {limit_reset_str}. "
+                            f"Sleeping for {int(delay_time * 10**3)} milliseconds"
                         )
 
                     # Log the error.
                     self.logger.error(f"{error_msg}. {retries_remaining}")
-                    time.sleep(err_delay)
+                    time.sleep(delay_time)
                     continue
 
                 elif s_json[ret_code] in self.ignore_codes:

--- a/pybit/exceptions.py
+++ b/pybit/exceptions.py
@@ -19,13 +19,15 @@ class FailedRequestError(Exception):
         message -- Explanation of the error.
         status_code -- The code number returned.
         time -- The time of the error.
+        resp_headers -- The response headers from API. None, if the request caused an error locally.
     """
 
-    def __init__(self, request, message, status_code, time):
+    def __init__(self, request, message, status_code, time, resp_headers):
         self.request = request
         self.message = message
         self.status_code = status_code
         self.time = time
+        self.resp_headers = resp_headers
         super().__init__(
             f"{message.capitalize()} (ErrCode: {status_code}) (ErrTime: {time})"
             f".\nRequest → {request}."
@@ -41,13 +43,15 @@ class InvalidRequestError(Exception):
         message -- Explanation of the error.
         status_code -- The code number returned.
         time -- The time of the error.
+        resp_headers -- The response headers from API. None, if the request caused an error locally.
     """
 
-    def __init__(self, request, message, status_code, time):
+    def __init__(self, request, message, status_code, time, resp_headers):
         self.request = request
         self.message = message
         self.status_code = status_code
         self.time = time
+        self.resp_headers = resp_headers
         super().__init__(
             f"{message} (ErrCode: {status_code}) (ErrTime: {time})"
             f".\nRequest → {request}."


### PR DESCRIPTION
Since the API changed from measuring the API rate limit per minute to per second and the rate limit reset timestamp is now in the response header not the response body, this change is necessary