### PR TITLE
add support to change TLD for NL, HK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Add methods for the [Institutional Loan](https://bybit-exchange.github.io/docs/v5/otc/margin-product-info) endpoints
+- `tld` arg for users in The Netherlands and Hong Kong
 
 ### Fixed
 - Options WebSocket failing to maintain connection (#164)

--- a/pybit/_http_manager.py
+++ b/pybit/_http_manager.py
@@ -22,11 +22,14 @@ try:
 except ImportError:
     from json.decoder import JSONDecodeError
 
-HTTP_URL = "https://{SUBDOMAIN}.{DOMAIN}.com"
+HTTP_URL = "https://{SUBDOMAIN}.{DOMAIN}.{TLD}"
 SUBDOMAIN_TESTNET = "api-testnet"
 SUBDOMAIN_MAINNET = "api"
 DOMAIN_MAIN = "bybit"
 DOMAIN_ALT = "bytick"
+TLD_MAIN = "com"
+TLD_NL = "nl"
+TLD_HK = "com.hk"
 
 
 def generate_signature(use_rsa_authentication, secret, param_str):
@@ -57,6 +60,7 @@ def generate_signature(use_rsa_authentication, secret, param_str):
 class _V5HTTPManager:
     testnet: bool = field(default=False)
     domain: str = field(default=DOMAIN_MAIN)
+    tld: str = field(default=TLD_MAIN)
     rsa_authentication: str = field(default=False)
     api_key: str = field(default=None)
     api_secret: str = field(default=None)
@@ -82,7 +86,7 @@ class _V5HTTPManager:
     def __post_init__(self):
         subdomain = SUBDOMAIN_TESTNET if self.testnet else SUBDOMAIN_MAINNET
         domain = DOMAIN_MAIN if not self.domain else self.domain
-        url = HTTP_URL.format(SUBDOMAIN=subdomain, DOMAIN=domain)
+        url = HTTP_URL.format(SUBDOMAIN=subdomain, DOMAIN=domain, TLD=self.tld)
         self.endpoint = url
 
         if not self.ignore_codes:


### PR DESCRIPTION
Per new support in the Bybit API docs

> important
>    Netherland users: use https://api.bybit.nl for mainnet
>    Hong Kong users: use https://api.bybit.com.hk for mainnet
>    Bybit cannot promise the stability and performance if you are still using api.bybit.com, and this domain has the possibility to be shutdown at any time for users from these two countries/areas.