### PR TITLE
chore: _WebSocketManager._on_error rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.7.1] - 2024-06-16
+### Added
+- `skip_utf8_validation` parameter (https://github.com/bybit-exchange/pybit/issues/224)
+
+### Changed
+- Now utf-8 validation is disabled by default. To enable pass `skip_utf8_validation=False` to `WebSocket()`
 
 ## Unreleased
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.7.1] - 2024-06-16
+## Unreleased
 ### Added
 - `skip_utf8_validation` parameter (https://github.com/bybit-exchange/pybit/issues/224)
+- [WebSocket Trading](https://bybit-exchange.github.io/docs/v5/websocket/trade/guideline) support
+- added "disconnect_on_exception" argument to `WebSocket` constructor. Pass `False` to keep the connection open on exception.
 
 ### Changed
 - Now utf-8 validation is disabled by default. To enable pass `skip_utf8_validation=False` to `WebSocket()`
+- Made all exceptions inherit from `PybitException`
+- replaced base "Exception" exceptions with "PybitException" inherited ones
+- rework on _on_error callback. Won't raise the exception when "disconnect_on_exception" is False
+- now exceptions handled in `WebSocket`'s `_on_error` callback will be logged along with the stacktrace.
 
-## Unreleased
-### Added
-- [WebSocket Trading](https://bybit-exchange.github.io/docs/v5/websocket/trade/guideline) support
+### Deprecated
+- `restart_on_error` in `WebSocket` constructor. Use `restart_on_ws_disconnect` instead
+- *Error exceptions. Replaced with *Exception exceptions(Ex.: `InvalidRequestError` replaced with `InvalidRequestException`)
 
 
 ## [5.7.0] - 2024-04-11

--- a/pybit/__init__.py
+++ b/pybit/__init__.py
@@ -1,1 +1,1 @@
-VERSION = "5.7.0"
+VERSION = "5.7.1"

--- a/pybit/__init__.py
+++ b/pybit/__init__.py
@@ -1,1 +1,1 @@
-VERSION = "5.7.1"
+VERSION = "5.7.0"

--- a/pybit/_utils.py
+++ b/pybit/_utils.py
@@ -1,0 +1,243 @@
+""" Utility classes and functions. """
+
+import inspect
+from abc import abstractmethod, ABC
+from typing import Optional, Any
+from warnings import warn
+from packaging import version
+from . import VERSION
+
+DEPRECATION_CONFIG = 'deprecation_config'
+
+
+class DeprecationConfig(ABC):
+    """ Base deprecation configuration class model """
+
+    modification_version: str
+    details: Optional[str]
+
+    def __init__(
+        self,
+        modification_version: str,
+        details: Optional[str] = None,
+    ) -> None:
+        self.modification_version = modification_version
+        self.details = details
+
+    @property
+    def should_be_modified(self) -> bool:
+        """ Check if there is a need to modify the function/class(remove, or replace some arguments)."""
+        return version.parse(VERSION) >= version.parse(self.modification_version)
+
+    @property
+    @abstractmethod
+    def warn_message(self) -> Optional[str]:
+        """ Return the deprecation message. 
+        This method should be implemented in the subclass.
+
+        Returns:
+            Optional[str]: 
+                The deprecation message. 
+                If there is no message to be shown, return None.
+        """
+
+    def warn(self):
+        """ Warn the user about the deprecation. """
+        msg = self.warn_message
+        if msg:
+            warn(msg, DeprecationWarning, 2)
+
+
+class ClassDeprecationConfig(DeprecationConfig):
+    """ Configuration class model for deprecated classes. 
+
+    Args:
+        remove_version (str): The version in which the class will be removed.
+        cls (type): The class to be deprecated.
+        details (Optional[str]): Additional details about the deprecation.
+        replacement (Optional[str | type]): The class to be used as a replacement(if any).
+    """
+
+    cls: type
+    replacement: Optional[str | type]
+
+    def __init__(
+        self,
+        remove_version: str,
+        cls: type,
+        details: Optional[str] = None,
+        replacement: Optional[str] = None,
+    ) -> None:
+        self.cls = cls
+        self.replacement = replacement
+        super().__init__(remove_version, details)
+
+    @property
+    def warn_message(self) -> str:
+        message = f'"{self.cls.__name__}" is deprecated and will be removed in version {self.modification_version}.'
+        if self.replacement:
+            replacement = self.replacement if isinstance(
+                self.replacement, str) else self.replacement.__name__
+            message += f' Use "{replacement}" instead.'
+        if self.details:
+            message += f' {self.details}'
+        return message
+
+
+class FunctionArgumentsDeprecationConfig(DeprecationConfig):
+    """ Configuration class model for deprecated function arguments. 
+
+    Args:
+        modification_version (str): 
+            The version in which the arguments will be removed/replaced.
+        to_be_removed (Optional[list[str] | str]): 
+            The arguments to be removed. Either a list of arguments 
+            or a single argument(if there is only one arg to be removed).
+        to_be_replaced (Optional[list[tuple[str, str]] | tuple[str, str]]): 
+            The arguments to be replaced. 
+            Either a list of tuples of arguments to be replaced or a single tuple
+            (if there is only one arg to be replaced). First element of the tuple is 
+            the argument to be replaced and the second element is the argument to be replaced with.
+        function_name (str): The name of the function.
+        kwargs (dict[str, Any]): The keyword arguments of the function.
+        details (Optional[str]): Additional details about the deprecation.
+    """
+    kwargs: dict[str, Any]
+    function_name: str
+    to_be_removed: list[str]
+    to_be_replaced: list[tuple[str, str]]
+
+    def __init__(
+        self,
+        modification_version: str,
+        to_be_removed: list[str] | str,
+        to_be_replaced: list[tuple[str, str]] | tuple[str, str],
+        function_name: str,
+        kwargs: dict[str, Any],
+        details: Optional[str] = None,
+    ) -> None:
+        self.kwargs = kwargs
+        self.function_name = function_name
+        self.to_be_removed = to_be_removed if isinstance(
+            to_be_removed, list) else [to_be_removed]
+        self.to_be_replaced = to_be_replaced if isinstance(
+            to_be_replaced, list) else [to_be_replaced]
+        super().__init__(modification_version, details)
+
+    @property
+    def warn_message(self) -> Optional[str]:
+        replace_args = list(
+            filter(lambda x: x[0] in self.kwargs, self.to_be_replaced)
+        )
+        if len(self.to_be_removed) + len(replace_args) == 0:
+            return None
+
+        message = (
+            f'The following arguments from function "{self.function_name}" '
+            'are deprecated and will be removed/replaced in version '
+            f'{self.modification_version}:'
+        )
+        if len(self.to_be_removed) > 0:
+            message += '\nArguments to be removed:\n\t'
+            message += '\n\t'.join(
+                [f'- "{x}"' for x in self.to_be_removed]
+            )
+        if len(replace_args) > 0:
+            message += '\nArguments to be replaced:\n\t'
+            message += '\n\t'.join(
+                [f'- "{x[0]}"(Replace with "{x[1]}")' for x in replace_args]
+            )
+        if self.details:
+            message += f' {self.details}'
+
+        return message
+
+
+def deprecate_class(
+        remove_version: str,
+        details: Optional[str] = None,
+        replacement: Optional[str | type] = None
+):
+    """ Decorator to deprecate a class. 
+
+    Args:
+        remove_version (str): The version in which the class will be removed.
+        details (Optional[str]): Additional details about the deprecation.
+        replacement (Optional[str | type]): The class to be used as a replacement(if any).
+    """
+    def decorator(cls):
+        if not inspect.isclass(cls):
+            raise AssertionError(
+                "This decorator can only be applied to classes.")
+        setattr(
+            cls,
+            DEPRECATION_CONFIG,
+            ClassDeprecationConfig(
+                remove_version=remove_version,
+                cls=cls,
+                details=details,
+                replacement=replacement,
+            )
+        )
+        init = cls.__init__
+
+        def __init__(self, *args, **kwargs):
+            if cls is self.__class__:
+                getattr(self, DEPRECATION_CONFIG).warn()
+            init(self, *args, **kwargs)
+        cls.__init__ = __init__
+        return cls
+    return decorator
+
+
+def deprecate_function_arguments(
+    modification_version: str,
+    to_be_removed: Optional[list[str] | str] = None,
+    to_be_replaced: Optional[list[tuple[str, str]] | tuple[str, str]] = None,
+    details: Optional[str] = None,
+):
+    """ Decorator to deprecate function arguments. 
+
+    Args:
+        modification_version (str): 
+            The version in which the arguments will be removed/replaced.
+        to_be_removed (Optional[list[str] | str]): 
+            The arguments to be removed. Either a list of arguments 
+            or a single argument(if there is only one arg to be removed).
+        to_be_replaced (Optional[list[tuple[str, str]] | tuple[str, str]]): 
+            The arguments to be replaced. 
+            Either a list of tuples of arguments to be replaced or a single tuple
+            (if there is only one arg to be replaced). First element of the tuple is 
+            the argument to be replaced and the second element is the argument to be replaced with.
+        details (Optional[str]): Additional details about the deprecation.
+    """
+    if to_be_removed is None and to_be_replaced is None:
+        raise ValueError(
+            'At least one of "to_be_removed" or "to_be_replaced" must be provided.'
+        )
+
+    def decorator(func):
+        if not inspect.isfunction(func):
+            raise AssertionError(
+                "This decorator can only be applied to functions.")
+        config = FunctionArgumentsDeprecationConfig(
+            modification_version=modification_version,
+            to_be_removed=to_be_removed or [],
+            to_be_replaced=to_be_replaced or [],
+            function_name=func.__qualname__,
+            kwargs={},
+            details=details,
+        )
+
+        def wrapper(*args, **kwargs):
+            config.kwargs = kwargs
+            config.warn()
+            return func(*args, **kwargs)
+
+        setattr(
+            wrapper,
+            DEPRECATION_CONFIG,
+            config,
+        )
+        return wrapper
+    return decorator

--- a/pybit/_websocket_stream.py
+++ b/pybit/_websocket_stream.py
@@ -60,7 +60,7 @@ class _WebSocketManager:
         disconnect_on_exception: bool = True,
         trace_logging=False,
         private_auth_expire=1,
-        skip_utf8_validation=True,
+        skip_utf8_validation=False,
     ):
         self.testnet = testnet
         self.domain = domain

--- a/pybit/_websocket_stream.py
+++ b/pybit/_websocket_stream.py
@@ -297,7 +297,7 @@ class _WebSocketManager:
         if should_raise:
             self.exit()
             logger.info(
-                "WebSocket %s closed because an exception was raised."
+                "WebSocket %s closed because an exception was raised. "
                 "If you want to keep the connection open, set disconnect_on_exception=False",
                 self.ws_name
             )

--- a/pybit/_websocket_stream.py
+++ b/pybit/_websocket_stream.py
@@ -37,6 +37,7 @@ class _WebSocketManager:
         restart_on_error=True,
         trace_logging=False,
         private_auth_expire=1,
+        skip_utf8_validation=True,
     ):
         self.testnet = testnet
         self.domain = domain
@@ -76,6 +77,13 @@ class _WebSocketManager:
         # Enable websocket-client's trace logging for extra debug information
         # on the websocket connection, including the raw sent & recv messages
         websocket.enableTrace(trace_logging)
+
+        # Set the skip_utf8_validation parameter to True to skip the utf-8
+        # validation of incoming messages. 
+        # Could be useful if incoming messages contain invalid utf-8 characters.
+        # Also disabling utf-8 validation could improve performance
+        # (more about performance: https://github.com/websocket-client/websocket-client).
+        self.skip_utf8_validation = skip_utf8_validation
 
         # Set initial state, initialize dictionary and connect.
         self._reset()
@@ -159,6 +167,7 @@ class _WebSocketManager:
                 target=lambda: self.ws.run_forever(
                     ping_interval=self.ping_interval,
                     ping_timeout=self.ping_timeout,
+                    skip_utf8_validation=self.skip_utf8_validation,
                 )
             )
 

--- a/pybit/exceptions.py
+++ b/pybit/exceptions.py
@@ -1,16 +1,126 @@
-class UnauthorizedExceptionError(Exception):
-    pass
+
+""" This module contains the exceptions for the Pybit package. """
+
+from ._utils import deprecate_class
 
 
-class InvalidChannelTypeError(Exception):
-    pass
+class PybitException(Exception):
+    """
+    Base exception class for all exceptions.
+    """
 
 
-class TopicMismatchError(Exception):
-    pass
+class WSConnectionNotEstablishedException(PybitException):
+    """
+    Exception raised when connection is not established.
+    """
+
+    def __init__(self):
+        super().__init__("WebSocket connection is not established. Please connect first.")
 
 
-class FailedRequestError(Exception):
+# =================== Authorization Exceptions ===================
+class AuthorizationException(PybitException):
+    """
+    Base exception class for all authorization exceptions.
+    """
+
+
+@deprecate_class(
+    '6.0',
+    replacement='NoCredentialsAuthorizationException',
+)
+class UnauthorizedExceptionError(AuthorizationException):
+    """
+    Exception raised for unauthorized requests.
+    """
+
+
+class NoCredentialsAuthorizationException(UnauthorizedExceptionError):
+    """
+    Exception raised when no credentials are provided.
+    """
+
+    def __init__(self):
+        super().__init__('"api_key" and/or "api_secret" are not set. They both are needed in order to access private sources')
+
+
+class AuthorizationFailedException(AuthorizationException):
+    """
+    Exception raised when authorization fails.
+    """
+
+    def __init__(self, ws_name: str, raw_message: str):
+        super().__init__(
+            f"Authorization for {ws_name} failed. Please check your "
+            f"API keys and resync your system time. Raw error: {raw_message}"
+        )
+# ===============================================================
+
+
+@deprecate_class(
+    '6.0',
+    replacement='InvalidChannelTypeException',
+)
+class InvalidChannelTypeError(PybitException):
+    """
+    Exception raised for invalid channel types.
+    """
+
+
+class InvalidChannelTypeException(InvalidChannelTypeError):
+    """
+    Exception raised for invalid channel types.
+    """
+
+    def __init__(self, provided_channel: str, available_channels: list[str]):
+        super().__init__(
+            f'Invalid channel type("{provided_channel}"). Available: {available_channels}')
+
+
+# ================ Topic Exceptions ========================
+class TopicException(PybitException):
+    """
+    Base exception class for all topic exceptions.
+    """
+
+
+@deprecate_class(
+    '6.0',
+    replacement='TopicMismatchException',
+)
+class TopicMismatchError(TopicException):
+    """
+    Exception raised for topic mismatch.
+    """
+
+
+class TopicMismatchException(TopicMismatchError):
+    """
+    Exception raised for topic mismatch.
+    """
+
+    def __init__(self):
+        super().__init__("Requested topic does not match channel_type")
+
+
+class AlreadySubscribedTopicException(TopicException):
+    """
+    Exception raised for already subscribed topics.
+    """
+
+    def __init__(self, topic: str):
+        super().__init__(f"Already subscribed to topic: {topic}")
+# ============================================================
+
+
+@deprecate_class(
+    '6.0',
+    replacement='FailedRequestException',
+)
+class FailedRequestError(PybitException):
+    # TODO: Remove this class in the next major release
+    # and copy-paste the __init__ method from this class to the replacement class
     """
     Exception raised for failed requests.
 
@@ -34,7 +144,26 @@ class FailedRequestError(Exception):
         )
 
 
-class InvalidRequestError(Exception):
+class FailedRequestException(FailedRequestError):
+    """
+    Exception raised for failed requests.
+
+    Attributes:
+        request -- The original request that caused the error.
+        message -- Explanation of the error.
+        status_code -- The code number returned.
+        time -- The time of the error.
+        resp_headers -- The response headers from API. None, if the request caused an error locally.
+    """
+
+
+@deprecate_class(
+    '6.0',
+    replacement='InvalidRequestException',
+)
+class InvalidRequestError(PybitException):
+    # TODO: Remove this class in the next major release
+    # and copy-paste the __init__ method from this class to the replacement class
     """
     Exception raised for returned Bybit errors.
 
@@ -56,3 +185,16 @@ class InvalidRequestError(Exception):
             f"{message} (ErrCode: {status_code}) (ErrTime: {time})"
             f".\nRequest → {request}."
         )
+
+
+class InvalidRequestException(FailedRequestError):
+    """
+    Exception raised for returned Bybit errors.
+
+    Attributes:
+        request -- The original request that caused the error.
+        message -- Explanation of the error.
+        status_code -- The code number returned.
+        time -- The time of the error.
+        resp_headers -- The response headers from API. None, if the request caused an error locally.
+    """

--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,6 @@ setup(
         "requests",
         "websocket-client",
         "websockets",
+        "packaging",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name='pybit',
-    version='5.7.1',
+    version='5.7.0',
     description='Python3 Bybit HTTP/WebSocket API Connector', 
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name='pybit',
-    version='5.7.0',
+    version='5.7.1',
     description='Python3 Bybit HTTP/WebSocket API Connector', 
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/test_pybit.py
+++ b/tests/test_pybit.py
@@ -1,6 +1,10 @@
-import unittest, time
+import sys
+import inspect
+import unittest
+import time
 from pybit.exceptions import InvalidChannelTypeError, TopicMismatchError
 from pybit.unified_trading import HTTP, WebSocket
+from pybit._utils import DEPRECATION_CONFIG
 
 # session uses Bybit's mainnet endpoint
 session = HTTP()
@@ -52,7 +56,7 @@ class HTTPTest(unittest.TestCase):
 
 class WebSocketTest(unittest.TestCase):
     # A very simple test to ensure we're getting something from WS.
-    def _callback_function(msg):
+    def _callback_function(self, msg):
         print(msg)
 
     def test_websocket(self):
@@ -80,12 +84,13 @@ class WebSocketTest(unittest.TestCase):
             )
 
             ws.order_stream(callback=self._callback_function)
-            
+
+
 class PrivateWebSocketTest(unittest.TestCase):
     # Connect to private websocket and see if we can auth.
-    def _callback_function(msg):
+    def _callback_function(self, msg):
         print(msg)
-    
+
     def test_private_websocket_connect(self):
         ws_private = WebSocket(
             testnet=True,
@@ -93,8 +98,55 @@ class PrivateWebSocketTest(unittest.TestCase):
             api_key="...",
             api_secret="...",
             trace_logging=True,
-            #private_auth_expire=10
+            # private_auth_expire=10
         )
-        
+
         ws_private.position_stream(callback=self._callback_function)
-        #time.sleep(10)
+        # time.sleep(10)
+
+
+class DeprecatedMembersTest(unittest.TestCase):
+    """ Test deprecated members. """
+
+    def _check_deprecated_function(self, func):
+        config = func.__dict__.get(DEPRECATION_CONFIG)
+        if config and config.should_be_modified:
+            message = (
+                f'There are arguments from function "{config.function_name}" '
+                'that are deprecated and must be removed in version '
+                f'{config.modification_version}:\n' +
+                ', '.join([f'"{x}"' for x in config.to_be_removed]) +
+                (', ' if len(config.to_be_removed) > 0 else '') +
+                ', '.join(
+                    [f'"{x[0]}"(Replaced with "{x[1]}")' for x in config.to_be_replaced])
+            )
+            raise AssertionError(message)
+
+    def _check_deprecated_class(self, cls):
+        config = cls[1].__dict__.get(DEPRECATION_CONFIG)
+        if config:
+            self.assertFalse(
+                config.should_be_modified,
+                f'Class "{cls[0]}" should be removed in version {config.modification_version}!'
+            )
+
+    def test_should_modify_deprecated_members(self):
+        """ Test if deprecated members(classes/functions) 
+        should be modified(removed/renamed) in current version. 
+        """
+        pybit_modules = [e[1]
+                         for e in sys.modules.items() if e[0].startswith('pybit.')]
+        for module in pybit_modules:
+            # Getting all classes from the module
+            classes = inspect.getmembers(module, inspect.isclass)
+            for cls in classes:
+                # Check all classes in the module
+                self._check_deprecated_class(cls)
+                # Check all functions in the class
+                for item in cls[1].__dict__.items():
+                    if inspect.isfunction(item[1]):
+                        self._check_deprecated_function(item[1])
+            # Check all functions in the module
+            functions = inspect.getmembers(module, inspect.isfunction)
+            for func in functions:
+                self._check_deprecated_function(func[1])

--- a/tests/test_pybit.py
+++ b/tests/test_pybit.py
@@ -1,8 +1,19 @@
+"""Tests for the Pybit API wrapper."""
+
 import sys
 import inspect
 import unittest
+from unittest import mock
 import time
-from pybit.exceptions import InvalidChannelTypeError, TopicMismatchError
+from websocket import (
+    WebSocketConnectionClosedException,
+    WebSocketTimeoutException
+)
+from pybit.exceptions import (
+    InvalidChannelTypeError,
+    TopicMismatchError,
+    NoCredentialsAuthorizationException
+)
 from pybit.unified_trading import HTTP, WebSocket
 from pybit._utils import DEPRECATION_CONFIG
 
@@ -103,6 +114,96 @@ class PrivateWebSocketTest(unittest.TestCase):
 
         ws_private.position_stream(callback=self._callback_function)
         # time.sleep(10)
+
+
+class WSOnErrorCallbackTest(unittest.TestCase):
+    """ Test WebSocket on_error callback. """
+
+    def test_tries_to_reconnect(self):
+        """ Test if WebSocket tries to reconnect on connection error. """
+        ws.restart_on_ws_disconnect = True
+        ws.attempting_connection = False
+        ws._reset = mock.MagicMock()
+        ws._connect = mock.MagicMock()
+        ws.exit = mock.MagicMock()
+        # WebSocketConnectionClosedException
+        ws._on_error(ws, WebSocketConnectionClosedException())
+        ws._reset.assert_called_once()
+        ws._connect.assert_called_once()
+        ws.exit.assert_called_once()
+        # WebSocketTimeoutException
+        ws._reset.reset_mock()
+        ws._connect.reset_mock()
+        ws.exit.reset_mock()
+        ws._on_error(ws, WebSocketTimeoutException())
+        ws._reset.assert_called_once()
+        ws._connect.assert_called_once()
+        ws.exit.assert_called_once()
+    
+    def test_doesnt_try_to_reconnect_when_restart_on_ws_disconnect_is_false(self):
+        """ Test if WebSocket doesn't try to reconnect when restart_on_ws_disconnect is False. """
+        ws.restart_on_ws_disconnect = False
+        ws.attempting_connection = False
+        ws._reset = mock.MagicMock()
+        ws._connect = mock.MagicMock()
+        ws.exit = mock.MagicMock()
+        self.assertRaises(
+            WebSocketConnectionClosedException,
+            ws._on_error, ws, WebSocketConnectionClosedException()
+        )
+        ws._reset.assert_not_called()
+        ws._connect.assert_not_called()
+        ws.exit.assert_called_once()
+
+    def test_disconnects_on_pybit_exception(self):
+        """ Test if WebSocket disconnects on Pybit exception. """
+        ws.restart_on_ws_disconnect = False
+        ws.attempting_connection = False
+        ws._connect = mock.MagicMock()
+        ws.exit = mock.MagicMock()
+        self.assertRaises(
+            NoCredentialsAuthorizationException,
+            ws._on_error, ws, NoCredentialsAuthorizationException()
+        )
+        ws._connect.assert_not_called()
+        ws.exit.assert_called_once()
+    
+    def test_ignores_exceptions_when_disconnect_on_exception_is_false(self):
+        """ Test if WebSocket ignores exceptions when disconnect_on_exception is False. """
+        ws.disconnect_on_exception = False
+        ws.restart_on_ws_disconnect = False
+        ws.attempting_connection = False
+        ws._connect = mock.MagicMock()
+        ws.exit = mock.MagicMock()
+        ws._on_error(ws, Exception())
+        ws._connect.assert_not_called()
+        ws.exit.assert_not_called()
+    
+    def test_raises_exception_when_disconnect_on_exception_is_true(self):
+        """ Test if WebSocket raises exception when disconnect_on_exception is True. """
+        ws.disconnect_on_exception = True
+        ws.restart_on_ws_disconnect = False
+        ws.attempting_connection = False
+        ws._connect = mock.MagicMock()
+        ws.exit = mock.MagicMock()
+        self.assertRaises(
+            Exception,
+            ws._on_error, ws, Exception()
+        )
+        ws._connect.assert_not_called()
+        ws.exit.assert_called_once()
+    
+    def test_doesn_nothing_when_attempting_connection_is_true(self):
+        """ Test if WebSocket does nothing when attempting_connection is True. """
+        ws.restart_on_ws_disconnect = True
+        ws.attempting_connection = True
+        ws._reset = mock.MagicMock()
+        ws._connect = mock.MagicMock()
+        ws.exit = mock.MagicMock()
+        ws._on_error(ws, WebSocketConnectionClosedException())
+        ws._reset.assert_not_called()
+        ws._connect.assert_not_called()
+        ws.exit.assert_not_called()
 
 
 class DeprecatedMembersTest(unittest.TestCase):


### PR DESCRIPTION
Closes #224 

## All the changes in this PR are backward compatible.

Below are described changes and reasons.

1. Added `skip_utf8_validation` argument, and set its value to `False` by default.
Reason is [these two lines](https://github.com/websocket-client/websocket-client/blob/77337ef76f1f38b14742ab28309f9ca51b8fb011/websocket/_app.py#L549-L550):
```python
if op_code == ABNF.OPCODE_TEXT and not skip_utf8_validation:
    data = data.decode("utf-8")
```
If `skip_utf8_validation` is `False`, the `websocket` package will try to decode the message. And the main problem is if this decode function will raise an exception, the `on_error` callback will not be called. That means when we'll receive a broken message - the connection will be closed. In my opinion, this is an unwanted behavior. On the other hand, yes, we can't do anything with the broken message, but, at least, we can handle the exception, caused by the broken message, using the `_on_error` callback.

2. Rework on the `_on_error` callback.
Old behavior: handle connection error. Other exceptions - disconnect and raise.
New behavior: handle connection error. Other exceptions - gives the choice to the user. If `disconnect_on_exception` is `True`(by default) the behavior will correspond to the old one. If `False` - exceptions will be only logged, and connection kept open.
Also, as a part of these changes, `restart_on_error` was renamed to `restart_on_ws_disconnect`. To make it clearer.

3. Rework on exceptions
Now every exception inherits from `PybitException` - base class for exceptions.
Also, for consistency purposes, existing *Error exceptions were deprecated. New exceptions named *Exception were created. I had replaced old exceptions with new ones everywhere in the code, because i preserved the backward compatibility(inherited new exceptions from the old one), but then realised that one may not use the best practices of checking the exception type(for example, checking the exception type by its name - `type(error).__name__ == "Error"`). Then it will break his code. So i reverted the changes. So, replacing the old exceptions with new ones task remains for the the new major release.

4. Deprecation utils.
I added two deprecation functions - `deprecate_class()` and `deprecate_function_arguments()`.
A warning will be printed whenever a deprecated class will be initialized, or a deprecated function argument will be passed as a key-value to function.
Also, i added tests, that won't pass if the current version is greater or equal to the deprecation version. So if some deprecated members should be removed in the current version, tests will tell about that.