### PR TITLE
feat: add delete_sub_uid() & removed utcnow()

### DIFF
--- a/pybit/_http_manager.py
+++ b/pybit/_http_manager.py
@@ -11,7 +11,7 @@ import json
 import logging
 import requests
 
-from datetime import datetime as dt
+from datetime import datetime as dt, timezone
 
 from .exceptions import FailedRequestError, InvalidRequestError
 from . import _helpers
@@ -221,7 +221,7 @@ class _V5HTTPManager:
                     request=f"{method} {path}: {req_params}",
                     message="Bad Request. Retries exceeded maximum.",
                     status_code=400,
-                    time=dt.utcnow().strftime("%H:%M:%S"),
+                    time=dt.now(timezone.utc).strftime("%H:%M:%S"),
                     resp_headers=None,
                 )
 
@@ -266,7 +266,7 @@ class _V5HTTPManager:
                         method, path, data=req_params, headers=headers
                     )
                 )
-            
+
             # Log the request.
             if self.log_requests:
                 if req_params:
@@ -307,7 +307,7 @@ class _V5HTTPManager:
                     request=f"{method} {path}: {req_params}",
                     message=error_msg,
                     status_code=s.status_code,
-                    time=dt.utcnow().strftime("%H:%M:%S"),
+                    time=dt.now(timezone.utc).strftime("%H:%M:%S"),
                     resp_headers=s.headers,
                 )
 
@@ -327,7 +327,7 @@ class _V5HTTPManager:
                         request=f"{method} {path}: {req_params}",
                         message="Conflict. Could not decode JSON.",
                         status_code=409,
-                        time=dt.utcnow().strftime("%H:%M:%S"),
+                        time=dt.now(timezone.utc).strftime("%H:%M:%S"),
                         resp_headers=s.headers,
                     )
 
@@ -380,7 +380,7 @@ class _V5HTTPManager:
                         request=f"{method} {path}: {req_params}",
                         message=s_json[ret_msg],
                         status_code=s_json[ret_code],
-                        time=dt.utcnow().strftime("%H:%M:%S"),
+                        time=dt.now(timezone.utc).strftime("%H:%M:%S"),
                         resp_headers=s.headers,
                     )
             else:

--- a/pybit/_v5_user.py
+++ b/pybit/_v5_user.py
@@ -160,6 +160,22 @@ class UserHTTP(_V5HTTPManager):
             auth=True,
         )
 
+    def delete_sub_uid(self, **kwargs):
+        """Delete a sub UID. Before deleting the sub UID, please make sure there is no asset. Use master user's api key only.
+
+        Returns:
+            Request results as dictionary.
+
+        Additional information:
+            https://bybit-exchange.github.io/docs/v5/user/rm-subuid
+        """
+        return self._submit_request(
+            method="POST",
+            path=f"{self.endpoint}{User.DELETE_SUB_UID}",
+            query=kwargs,
+            auth=True,
+        )
+
     def get_affiliate_user_info(self, **kwargs):
         """This API is used for affiliate to get their users information
 

--- a/pybit/legacy/_http_manager.py
+++ b/pybit/legacy/_http_manager.py
@@ -5,7 +5,7 @@ import json
 import logging
 import requests
 
-from datetime import datetime as dt
+from datetime import datetime as dt, timezone
 
 from .exceptions import FailedRequestError, InvalidRequestError
 from .. import VERSION
@@ -199,7 +199,7 @@ class _HTTPManager:
                     request=f"{method} {path}: {req_params}",
                     message="Bad Request. Retries exceeded maximum.",
                     status_code=400,
-                    time=dt.utcnow().strftime("%H:%M:%S")
+                    time=dt.now(timezone.utc).strftime("%H:%M:%S")
                 )
 
             retries_remaining = f"{retries_attempted} retries remain."
@@ -308,7 +308,7 @@ class _HTTPManager:
                     request=f"{method} {path}: {req_params}",
                     message=error_msg,
                     status_code=s.status_code,
-                    time=dt.utcnow().strftime("%H:%M:%S")
+                    time=dt.now(timezone.utc).strftime("%H:%M:%S")
                 )
 
             # Convert response to dictionary, or raise if requests error.
@@ -327,7 +327,7 @@ class _HTTPManager:
                         request=f"{method} {path}: {req_params}",
                         message="Conflict. Could not decode JSON.",
                         status_code=409,
-                        time=dt.utcnow().strftime("%H:%M:%S")
+                        time=dt.now(timezone.utc).strftime("%H:%M:%S")
                     )
 
             if "usdc" in path:
@@ -389,7 +389,7 @@ class _HTTPManager:
                         request=f"{method} {path}: {req_params}",
                         message=s_json[ret_msg],
                         status_code=s_json[ret_code],
-                        time=dt.utcnow().strftime("%H:%M:%S")
+                        time=dt.now(timezone.utc).strftime("%H:%M:%S")
                     )
             else:
                 if self.record_request_time:
@@ -729,7 +729,7 @@ class _V3HTTPManager:
                     request=f"{method} {path}: {req_params}",
                     message="Bad Request. Retries exceeded maximum.",
                     status_code=400,
-                    time=dt.utcnow().strftime("%H:%M:%S")
+                    time=dt.now(timezone.utc).strftime("%H:%M:%S")
                 )
 
             retries_remaining = f"{retries_attempted} retries remain."
@@ -813,7 +813,7 @@ class _V3HTTPManager:
                     request=f"{method} {path}: {req_params}",
                     message=error_msg,
                     status_code=s.status_code,
-                    time=dt.utcnow().strftime("%H:%M:%S")
+                    time=dt.now(timezone.utc).strftime("%H:%M:%S")
                 )
 
             # Convert response to dictionary, or raise if requests error.
@@ -832,7 +832,7 @@ class _V3HTTPManager:
                         request=f"{method} {path}: {req_params}",
                         message="Conflict. Could not decode JSON.",
                         status_code=409,
-                        time=dt.utcnow().strftime("%H:%M:%S")
+                        time=dt.now(timezone.utc).strftime("%H:%M:%S")
                     )
 
             ret_code = "retCode"
@@ -889,7 +889,7 @@ class _V3HTTPManager:
                         request=f"{method} {path}: {req_params}",
                         message=s_json[ret_msg],
                         status_code=s_json[ret_code],
-                        time=dt.utcnow().strftime("%H:%M:%S")
+                        time=dt.now(timezone.utc).strftime("%H:%M:%S")
                     )
             else:
                 if self.record_request_time:

--- a/pybit/user.py
+++ b/pybit/user.py
@@ -13,6 +13,7 @@ class User(str, Enum):
     DELETE_SUB_API_KEY = "/v5/user/delete-sub-api"
     GET_AFFILIATE_USER_INFO = "/v5/user/aff-customer-info"
     GET_UID_WALLET_TYPE = "/v5/user/get-member-type"
+    DELETE_SUB_UID = "/v5/user/del-submember"
 
     def __str__(self) -> str:
         return self.value


### PR DESCRIPTION
- [x] Add a method named `delete_sub_uid` which implements [Delete Sub UID](https://bybit-exchange.github.io/docs/v5/user/rm-subuid) for deleting a subaccount with its `UID`
- [x] Replace references of `dt.utcnow()` with `dt.now(timezone.utc)` following its deprecation: https://blog.miguelgrinberg.com/post/it-s-time-for-a-change-datetime-utcnow-is-now-deprecated 
- [ ] Update [Delete Sub UID](https://bybit-exchange.github.io/docs/v5/user/rm-subuid) documentation ([Docusaurus Source](https://github.com/bybit-exchange/docs/blob/master/docs/v5/user/rm-subuid.mdx)) to include an example for the Python SDK:

```python
from pybit.unified_trading import HTTP
session = HTTP(
    testnet=True,
    api_key="XXXXX",
    api_secret="XXXXX",
)
print(session.delete_sub_uid(
    subMemberId="XXXXX"
))
```

Here's a use case for **Delete Sub UID**. I manage a codebase that automates the following processes:

- Create subaccounts
- Configure subaccounts (hedge mode, leverage, partial SL mode, isolated mode)
- Generate their API keys
- Delete expired keys and generate new ones
- Transfer assets between subaccounts
- Place orders and track PnL on subaccounts

My tests must ensure that subaccounts can be created and configured successfully. Once this is confirmed, it deletes the subaccount.

cc: @dextertd @woodliang10