### PR TITLE
Fixed hanging on WebSocketTimeoutException, added termination to exit

### DIFF
--- a/pybit/_websocket_stream.py
+++ b/pybit/_websocket_stream.py
@@ -306,7 +306,7 @@ class _WebSocketManager:
             import signal
             p_id = os.getpid()
             logger.error("Forcing kill after receiving critical error")
-            os.kill(p_id, signal.SIGTERM)
+            os.kill(1)
 
 
 class _V5WebSocketManager(_WebSocketManager):

--- a/pybit/_websocket_stream.py
+++ b/pybit/_websocket_stream.py
@@ -175,13 +175,14 @@ class _WebSocketManager:
 
             # If connection was not successful, raise error.
             if not infinitely_reconnect and retries <= 0:
+                self.terminate = True
+                self.exit()
                 raise websocket.WebSocketTimeoutException(
                     f"WebSocket {self.ws_name} ({self.endpoint}) connection "
                     f"failed. Too many connection attempts. pybit will no "
                     f"longer try to reconnect."
                 )
-                self.terminate = True
-                self.exit()
+
 
 
         logger.info(f"WebSocket {self.ws_name} connected")

--- a/pybit/_websocket_stream.py
+++ b/pybit/_websocket_stream.py
@@ -174,14 +174,17 @@ class _WebSocketManager:
                     break
 
             # If connection was not successful, raise error.
-            if not infinitely_reconnect and retries <= 0:
+            try:
+                if not infinitely_reconnect and retries <= 0:
+                    raise websocket.WebSocketTimeoutException(
+                        f"WebSocket {self.ws_name} ({self.endpoint}) connection "
+                        f"failed. Too many connection attempts. pybit will no "
+                        f"longer try to reconnect."
+                    )
+            except websocket.WebSocketTimeoutException as error:
+                logger.error(error)
                 self.terminate = True
                 self.exit()
-                raise websocket.WebSocketTimeoutException(
-                    f"WebSocket {self.ws_name} ({self.endpoint}) connection "
-                    f"failed. Too many connection attempts. pybit will no "
-                    f"longer try to reconnect."
-                )
 
         logger.info(f"WebSocket {self.ws_name} connected")
 

--- a/pybit/_websocket_stream.py
+++ b/pybit/_websocket_stream.py
@@ -255,7 +255,14 @@ class _WebSocketManager:
         self._send_custom_ping()
 
     def _send_custom_ping(self):
-        self.ws.send(self.custom_ping_message)
+        try:
+            self.ws.send(self.custom_ping_message)
+        except websocket.WebSocketTimeoutException as error:
+            import sys
+            # Logging error and exiting hanging, non-reposing app (Let it fall).
+            logger.error(f"WebSocket {self.ws_name} not responding, error: {error}")
+            sys.exit()
+
 
     def _send_initial_ping(self):
         """https://github.com/bybit-exchange/pybit/issues/164"""

--- a/pybit/_websocket_stream.py
+++ b/pybit/_websocket_stream.py
@@ -12,6 +12,7 @@ from uuid import uuid4
 from . import _helpers
 
 logger = logging.getLogger(__name__)
+from websocket._exceptions import WebSocketConnectionClosedException
 
 SUBDOMAIN_TESTNET = "stream-testnet"
 SUBDOMAIN_MAINNET = "stream"
@@ -263,7 +264,7 @@ class _WebSocketManager:
     def _send_custom_ping(self):
         try:
             self.ws.send(self.custom_ping_message)
-        except websocket.WebSocketTimeoutException as error:
+        except WebSocketConnectionClosedException as error:
             # Logging error and exiting hanging, non-reposing app (Let it fall).
             logger.error(f"WebSocket {self.ws_name} not responding, error: {error}")
             self.terminate = True

--- a/pybit/_websocket_stream.py
+++ b/pybit/_websocket_stream.py
@@ -305,6 +305,7 @@ class _WebSocketManager:
         if self.terminate:
             import signal
             p_id = os.getpid()
+            logger.error("Forcing kill after receiving critical error")
             os.kill(p_id, signal.SIGTERM)
 
 

--- a/pybit/_websocket_stream.py
+++ b/pybit/_websocket_stream.py
@@ -306,7 +306,7 @@ class _WebSocketManager:
             import signal
             p_id = os.getpid()
             logger.error("Forcing kill after receiving critical error")
-            os.kill(1)
+            os.kill(1, signal.SIGKILL)
 
 
 class _V5WebSocketManager(_WebSocketManager):


### PR DESCRIPTION
I've encountered websocket.WebSocketTimeoutException and my container was hanging for several days ignoring my restart policy.

```

bybit-data-miner-1  | Exception in thread Thread-80:
bybit-data-miner-1  | Traceback (most recent call last):
bybit-data-miner-1  |   File "/usr/local/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
bybit-data-miner-1  |     self.run()
bybit-data-miner-1  |   File "/usr/local/lib/python3.10/threading.py", line 1378, in run
bybit-data-miner-1  |     self.function(*self.args, **self.kwargs)
bybit-data-miner-1  |   File "/usr/local/lib/python3.10/site-packages/pybit/_websocket_stream.py", line 258, in _send_custom_ping
bybit-data-miner-1  |     self.ws.send(self.custom_ping_message)
bybit-data-miner-1  |   File "/usr/local/lib/python3.10/site-packages/websocket/_app.py", line 284, in send
bybit-data-miner-1  |     raise WebSocketConnectionClosedException("Connection is already closed.")
bybit-data-miner-1  | websocket._exceptions.WebSocketConnectionClosedException: Connection is already closed.
```

I've added a terminate field when WebSocket has already closed and all retries have had exceeded. So now WebSocketConnection causes container to terminate and restart on restart policy.