### PR TITLE
Add ping timer management in WebSocketManager

### DIFF
--- a/pybit/_websocket_stream.py
+++ b/pybit/_websocket_stream.py
@@ -266,6 +266,7 @@ class _WebSocketManager:
         timer = threading.Timer(
             self.ping_interval, self._send_custom_ping
         )
+        self.ping_timer = timer
         timer.start()
 
     @staticmethod
@@ -288,7 +289,8 @@ class _WebSocketManager:
         """
         Closes the websocket connection.
         """
-
+        if self.ping_timer:
+            self.ping_timer.cancel()
         self.ws.close()
         while self.ws.sock:
             continue


### PR DESCRIPTION
This update introduces a ping_timer attribute to the _WebSocketManager class, ensuring that the ping timer is properly canceled when closing the websocket connection.