### PR TITLE
[PRE-RELEASE] pybit v5.15.0rc2

### DIFF
--- a/pybit/__init__.py
+++ b/pybit/__init__.py
@@ -1,1 +1,1 @@
-VERSION = "5.15.0rc1"
+VERSION = "5.15.0rc2"

--- a/pybit/_v5_asset.py
+++ b/pybit/_v5_asset.py
@@ -705,3 +705,123 @@ class AssetHTTP(_V5HTTPManager):
             query=kwargs,
             auth=True,
         )
+
+    def get_fiat_balance(self, **kwargs):
+        """
+        Returns:
+            Request results as dictionary.
+
+        Additional information:
+            https://bybit-exchange.github.io/docs/v5/asset/fiat-convert/balance-query
+        """
+        return self._submit_request(
+            method="GET",
+            path=f"{self.endpoint}{Asset.GET_FIAT_BALANCE}",
+            query=kwargs,
+            auth=True,
+        )
+
+    def get_fiat_trading_pair_list(self, **kwargs):
+        """
+        Returns:
+            Request results as dictionary.
+
+        Additional information:
+            https://bybit-exchange.github.io/docs/v5/asset/fiat-convert/query-coin-list
+        """
+        return self._submit_request(
+            method="GET",
+            path=f"{self.endpoint}{Asset.GET_FIAT_TRADING_PAIR_LIST}",
+            query=kwargs,
+            auth=True,
+        )
+
+    def get_fiat_convert_history(self, **kwargs):
+        """
+        Returns:
+            Request results as dictionary.
+
+        Additional information:
+            https://bybit-exchange.github.io/docs/v5/asset/fiat-convert/query-trade-history
+        """
+        return self._submit_request(
+            method="GET",
+            path=f"{self.endpoint}{Asset.GET_FIAT_CONVERT_HISTORY}",
+            query=kwargs,
+            auth=True,
+        )
+
+    def request_a_quote_fiat_convert(self, **kwargs):
+        """
+        Required args:
+            fromCoin (string): Convert from coin (coin to sell)
+            fromCoinType (string): fiat or crypto
+            toCoin (string): Convert to coin (coin to buy)
+            toCoinType (string): fiat or crypto
+            requestAmount (string): Request coin amount (the amount you want to sell)
+
+        Returns:
+            Request results as dictionary.
+
+        Additional information:
+            https://bybit-exchange.github.io/docs/v5/asset/fiat-convert/quote-apply
+        """
+        return self._submit_request(
+            method="POST",
+            path=f"{self.endpoint}{Asset.REQUEST_A_QUOTE_FIAT_CONVERT}",
+            query=kwargs,
+            auth=True,
+        )
+
+    def get_fiat_reference_price(self, **kwargs):
+        """
+        Required args:
+            symbol (string): Coin pair, such as EUR-USDT
+
+        Returns:
+            Request results as dictionary.
+
+        Additional information:
+            https://bybit-exchange.github.io/docs/v5/asset/fiat-convert/reference-price
+        """
+        return self._submit_request(
+            method="GET",
+            path=f"{self.endpoint}{Asset.GET_FIAT_REFERENCE_PRICE}",
+            query=kwargs,
+            auth=True,
+        )
+
+    def confirm_a_quote_fiat_convert(self, **kwargs):
+        """
+        Required args:
+            quoteTxId (string): The quote tx ID from Request a Quote
+            subUserId (string): The user's sub userId in bybit
+
+        Returns:
+            Request results as dictionary.
+
+        Additional information:
+            https://bybit-exchange.github.io/docs/v5/asset/fiat-convert/confirm-quote
+        """
+        return self._submit_request(
+            method="POST",
+            path=f"{self.endpoint}{Asset.CONFIRM_A_QUOTE_FIAT_CONVERT}",
+            query=kwargs,
+            auth=True,
+        )
+
+    def get_fiat_convert_status(self, **kwargs):
+        """
+        Returns:
+            Request results as dictionary.
+
+        Additional information:
+            https://bybit-exchange.github.io/docs/v5/asset/fiat-convert/query-trade
+        """
+        return self._submit_request(
+            method="GET",
+            path=f"{self.endpoint}{Asset.GET_FIAT_CONVERT_STATUS}",
+            query=kwargs,
+            auth=True,
+        )
+    

--- a/pybit/_v5_asset.py
+++ b/pybit/_v5_asset.py
@@ -664,3 +664,44 @@ class AssetHTTP(_V5HTTPManager):
             query=kwargs,
             auth=True,
         )
+
+    def get_asset_overview(self, **kwargs):
+        """Query master account or one subaccounts' total assets and detailed asset holdings across different accounts and product categories.
+
+        Required args:
+            memberId (string): User ID. When using master API key to query sub account assets, this field is required
+
+        Returns:
+            Request results as dictionary.
+
+        Additional information:
+            https://bybit-exchange.github.io/docs/v5/asset/balance/asset-overview
+        """
+        return self._submit_request(
+            method="GET",
+            path=f"{self.endpoint}{Asset.GET_ASSET_OVERVIEW}",
+            query=kwargs,
+            auth=True,
+        )
+
+    def get_funding_acc_history(self, **kwargs):
+        """Return transaction log in Funding Account.
+
+        Required args:
+            createTimeFrom (string): Start timestamp (seconds)
+            createTimeTo (string): End timestamp (seconds)
+            limit (string): Limit for data size per page, [1; 100]
+            cursor (string): Cursor, used for pagination
+
+        Returns:
+            Request results as dictionary.
+
+        Additional information:
+            https://bybit-exchange.github.io/docs/v5/asset/fund-history
+        """
+        return self._submit_request(
+            method="GET",
+            path=f"{self.endpoint}{Asset.GET_FUNDING_ACC_HISTORY}",
+            query=kwargs,
+            auth=True,
+        )

--- a/pybit/_v5_asset.py
+++ b/pybit/_v5_asset.py
@@ -824,4 +824,3 @@ class AssetHTTP(_V5HTTPManager):
             query=kwargs,
             auth=True,
         )
-    

--- a/pybit/_v5_broker.py
+++ b/pybit/_v5_broker.py
@@ -130,3 +130,62 @@ class BrokerHTTP(_V5HTTPManager):
             query=kwargs,
             auth=True,
         )
+
+    def get_broker_all_rate_limits(self, **kwargs) -> dict:
+        """
+        Required args:
+            limit (string): Limit for data size per page.
+            cursor (string): Cursor.
+            uids (string): Multiple UIDs across different master accounts, separated by commas. Returns all subaccounts by default
+
+        Returns:
+            Request results as dictionary.
+
+        Additional information:
+            https://bybit-exchange.github.io/docs/v5/broker/exchange-broker/rate-limit/query-all
+        """
+
+        return self._submit_request(
+            method="GET",
+            path=f"{self.endpoint}{Broker.GET_BROKER_ALL_RATE_LIMITS}",
+            query=kwargs,
+            auth=True,
+        )
+
+    def get_broker_rate_limit_cap(self, **kwargs) -> dict:
+        """
+        Returns:
+            Request results as dictionary.
+
+        Additional information:
+            https://bybit-exchange.github.io/docs/v5/broker/exchange-broker/rate-limit/query-cap
+        """
+
+        return self._submit_request(
+            method="GET",
+            path=f"{self.endpoint}{Broker.GET_BROKER_RATE_LIMIT_CAP}",
+            query=kwargs,
+            auth=True,
+        )
+
+    def set_broker_rate_limit(self, **kwargs) -> dict:
+        """
+        Required args:
+            list (array): List of data
+                uids (string): Multiple UIDs separated by commas, e.g., "uid1,uid2,uid3"
+                bizType (string): Business type
+                rate (integer): API rate limit per second
+
+        Returns:
+            Request results as dictionary.
+
+        Additional information:
+            https://bybit-exchange.github.io/docs/v5/broker/exchange-broker/rate-limit/set
+        """
+
+        return self._submit_request(
+            method="POST",
+            path=f"{self.endpoint}{Broker.SET_BROKER_RATE_LIMIT}",
+            query=kwargs,
+            auth=True,
+        )

--- a/pybit/_v5_crypto_loan.py
+++ b/pybit/_v5_crypto_loan.py
@@ -680,3 +680,21 @@ class CryptoLoanHTTP(_V5HTTPManager):
             query=kwargs,
             auth=True,
         )
+
+    def get_max_loan_amount_new_crypto_loan(self, **kwargs):
+        """
+        Required args:
+            currency (string): Coin to borrow
+
+        Returns:
+            Request results as dictionary.
+
+        Additional information:
+            https://bybit-exchange.github.io/docs/v5/new-crypto-loan/max-loan-amt
+        """
+        return self._submit_request(
+            method="POST",
+            path=f"{self.endpoint}{CryptoLoan.GET_MAX_LOAN_AMOUNT_NEW_CRYPTO_LOAN}",
+            query=kwargs,
+            auth=True,
+        )

--- a/pybit/_v5_position.py
+++ b/pybit/_v5_position.py
@@ -347,4 +347,3 @@ class PositionHTTP(_V5HTTPManager):
             query=kwargs,
             auth=True,
         )
-    

--- a/pybit/_v5_position.py
+++ b/pybit/_v5_position.py
@@ -328,3 +328,23 @@ class PositionHTTP(_V5HTTPManager):
             query=kwargs,
             auth=True,
         )
+
+    def confirm_new_risk_limit(self, **kwargs):
+        """
+        Required args:
+            category (string): Product type. linear, inverse
+            symbol (string): Symbol name
+
+        Returns:
+            Request results as dictionary.
+
+        Additional information:
+            https://bybit-exchange.github.io/docs/v5/position/confirm-mmr
+        """
+        return self._submit_request(
+            method="POST",
+            path=f"{self.endpoint}{Position.CONFIRM_PENDING_MMR}",
+            query=kwargs,
+            auth=True,
+        )
+    

--- a/pybit/_v5_spot_margin_trade.py
+++ b/pybit/_v5_spot_margin_trade.py
@@ -377,3 +377,18 @@ class SpotMarginTradeHTTP(_V5HTTPManager):
             query=kwargs,
             auth=True,
         )
+
+    def spot_margin_trade_get_currency_data(self, **kwargs):
+        """Get spot margin currency data information.
+
+        Returns:
+            Request results as dictionary.
+
+        Additional information:
+            https://bybit-exchange.github.io/docs/v5/spot-margin-uta/currency-data
+        """
+        return self._submit_request(
+            method="GET",
+            path=f"{self.endpoint}{SpotMarginTrade.GET_CURRENCY_DATA}",
+            query=kwargs,
+        )

--- a/pybit/_v5_spread.py
+++ b/pybit/_v5_spread.py
@@ -8,7 +8,7 @@ PUBLIC_WSS = "wss://{SUBDOMAIN}.{DOMAIN}.com/v5/public/spread"
 
 
 class SpreadHTTP(_V5HTTPManager):
-    def get_instruments_info(self, **kwargs) -> dict:
+    def spread_get_instruments_info(self, **kwargs) -> dict:
         """
         Returns:
             Request results as dictionary.
@@ -23,7 +23,7 @@ class SpreadHTTP(_V5HTTPManager):
         )
         return request
 
-    def get_orderbook(self, **kwargs) -> dict:
+    def spread_get_orderbook(self, **kwargs) -> dict:
         """
         Returns:
             Request results as dictionary.
@@ -37,7 +37,7 @@ class SpreadHTTP(_V5HTTPManager):
             query=kwargs,
         )
 
-    def get_tickers(self, **kwargs) -> dict:
+    def spread_get_tickers(self, **kwargs) -> dict:
         """
         Returns:
             Request results as dictionary.
@@ -51,7 +51,7 @@ class SpreadHTTP(_V5HTTPManager):
             query=kwargs,
         )
 
-    def get_public_trade_history(self, **kwargs) -> dict:
+    def spread_get_public_trade_history(self, **kwargs) -> dict:
         """
         Returns:
             Request results as dictionary.
@@ -65,7 +65,7 @@ class SpreadHTTP(_V5HTTPManager):
             query=kwargs,
         )
 
-    def place_order(self, **kwargs) -> dict:
+    def spread_place_order(self, **kwargs) -> dict:
         """
         Required args:
             category (string): Product type Unified account: spot, linear, optionNormal account: linear, inverse. Please note that category is not involved with business logic
@@ -86,7 +86,7 @@ class SpreadHTTP(_V5HTTPManager):
             auth=True,
         )
 
-    def amend_order(self, **kwargs) -> dict:
+    def spread_amend_order(self, **kwargs) -> dict:
         """
         Required args:
             symbol (string): Spread combination symbol name
@@ -104,7 +104,7 @@ class SpreadHTTP(_V5HTTPManager):
             auth=True,
         )
 
-    def cancel_order(self, **kwargs) -> dict:
+    def spread_cancel_order(self, **kwargs) -> dict:
         """
         Returns:
             Request results as dictionary.
@@ -119,7 +119,7 @@ class SpreadHTTP(_V5HTTPManager):
             auth=True,
         )
 
-    def cancel_all_orders(self, **kwargs) -> dict:
+    def spread_cancel_all_orders(self, **kwargs) -> dict:
         """
         Returns:
             Request results as dictionary.
@@ -134,7 +134,7 @@ class SpreadHTTP(_V5HTTPManager):
             auth=True,
         )
 
-    def get_open_orders(self, **kwargs) -> dict:
+    def spread_get_open_orders(self, **kwargs) -> dict:
         """
         Returns:
             Request results as dictionary.
@@ -149,7 +149,7 @@ class SpreadHTTP(_V5HTTPManager):
             auth=True,
         )
 
-    def get_order_history(self, **kwargs) -> dict:
+    def spread_get_order_history(self, **kwargs) -> dict:
         """
         Returns:
             Request results as dictionary.
@@ -164,7 +164,7 @@ class SpreadHTTP(_V5HTTPManager):
             auth=True,
         )
 
-    def get_trade_history(self, **kwargs) -> dict:
+    def spread_get_trade_history(self, **kwargs) -> dict:
         """
         Returns:
             Request results as dictionary.

--- a/pybit/_v5_user.py
+++ b/pybit/_v5_user.py
@@ -284,3 +284,38 @@ class UserHTTP(_V5HTTPManager):
             query=kwargs,
             auth=True,
         )
+
+    def sign_agreement(self, **kwargs):
+        """
+        Required args:
+            category (integer): 2: Metals commodity contracts
+            agree (boolean): true
+
+        Returns:
+            Request results as dictionary.
+
+        Additional information:
+            https://bybit-exchange.github.io/docs/v5/user/sign-agreement
+        """
+        return self._submit_request(
+            method="POST",
+            path=f"{self.endpoint}{User.SIGN_AGREEMENT}",
+            query=kwargs,
+            auth=True,
+        )
+
+    def get_friend_referrals(self, **kwargs):
+        """
+        Returns:
+            Request results as dictionary.
+
+        Additional information:
+            https://bybit-exchange.github.io/docs/v5/user/friend-referral
+        """
+        return self._submit_request(
+            method="GET",
+            path=f"{self.endpoint}{User.GET_FRIEND_REFERRALS}",
+            query=kwargs,
+            auth=True,
+        )
+    

--- a/pybit/_v5_user.py
+++ b/pybit/_v5_user.py
@@ -318,4 +318,3 @@ class UserHTTP(_V5HTTPManager):
             query=kwargs,
             auth=True,
         )
-    

--- a/pybit/asset.py
+++ b/pybit/asset.py
@@ -48,6 +48,15 @@ class Asset(str, Enum):
     GET_EXCHANGE_HISTORY_SMALL_BALANCE = "/v5/asset/covert/small-balance-history"
     GET_ASSET_OVERVIEW = "/v5/asset/asset-overview"
     GET_FUNDING_ACC_HISTORY = "/v5/asset/fundinghistory"
+    # Fiat
+    GET_FIAT_BALANCE = "/v5/fiat/balance-query"
+    GET_FIAT_TRADING_PAIR_LIST = "/v5/fiat/query-coin-list"
+    GET_FIAT_CONVERT_HISTORY = "/v5/fiat/query-trade-history"
+    REQUEST_A_QUOTE_FIAT_CONVERT = "/v5/fiat/quote-apply"
+    GET_FIAT_REFERENCE_PRICE = "/v5/fiat/reference-price"
+    CONFIRM_A_QUOTE_FIAT_CONVERT = "/v5/fiat/trade-execute"
+    GET_FIAT_CONVERT_STATUS = "/v5/fiat/trade-query"
+
 
     def __str__(self) -> str:
         return self.value

--- a/pybit/asset.py
+++ b/pybit/asset.py
@@ -46,6 +46,8 @@ class Asset(str, Enum):
     REQUEST_A_QUOTE_SMALL_BALANCE = "/v5/asset/covert/get-quote"
     CONFIRM_A_QUOTE_SMALL_BALANCE = "/v5/asset/covert/small-balance-execute"
     GET_EXCHANGE_HISTORY_SMALL_BALANCE = "/v5/asset/covert/small-balance-history"
+    GET_ASSET_OVERVIEW = "/v5/asset/asset-overview"
+    GET_FUNDING_ACC_HISTORY = "/v5/asset/fundinghistory"
 
     def __str__(self) -> str:
         return self.value

--- a/pybit/broker.py
+++ b/pybit/broker.py
@@ -9,6 +9,9 @@ class Broker(str, Enum):
     GET_VOUCHER_SPEC = "/v5/broker/award/info"
     ISSUE_VOUCHER = "/v5/broker/award/distribute-award"
     GET_ISSUED_VOUCHER = "/v5/broker/award/distribution-record"
+    GET_BROKER_ALL_RATE_LIMITS="/v5/broker/apilimit/query-all"
+    GET_BROKER_RATE_LIMIT_CAP="/v5/broker/apilimit/query-cap"
+    SET_BROKER_RATE_LIMIT="/v5/broker/apilimit/set"
 
     def __str__(self) -> str:
         return self.value

--- a/pybit/crypto_loan.py
+++ b/pybit/crypto_loan.py
@@ -22,6 +22,7 @@ class CryptoLoan(str, Enum):
     ADJUST_COLLATERAL_AMOUNT_NEW_CRYPTO_LOAN = "/v5/crypto-loan-common/adjust-ltv"
     GET_LTV_ADJUSTMENT_HISTORY_NEW_CRYPTO_LOAN = "/v5/crypto-loan-common/adjustment-history"
     GET_POSITION_NEW_CRYPTO_LOAN = "/v5/crypto-loan-common/position"
+    GET_MAX_LOAN_AMOUNT_NEW_CRYPTO_LOAN = "/v5/crypto-loan-common/max-loan"
 
     # Flexible loans
     BORROW_FLEXIBLE_CRYPTO_LOAN = "/v5/crypto-loan-flexible/borrow"

--- a/pybit/position.py
+++ b/pybit/position.py
@@ -16,6 +16,7 @@ class Position(str, Enum):
     MOVE_POSITION = "/v5/position/move-positions"
     GET_MOVE_POSITION_HISTORY = "/v5/position/move-history"
     GET_CLOSED_OPTIONS_POSITIONS = "/v5/position/get-closed-positions"
+    CONFIRM_PENDING_MMR = "/v5/position/confirm-pending-mmr"
 
     def __str__(self) -> str:
         return self.value

--- a/pybit/spot_margin_trade.py
+++ b/pybit/spot_margin_trade.py
@@ -27,6 +27,7 @@ class SpotMarginTrade(str, Enum):
     GET_POSITION_TIERS = "/v5/spot-margin-trade/position-tiers"
     GET_COIN_STATE = "/v5/spot-margin-trade/coinstate"
     GET_REPAYMENT_AVAILABLE_AMOUNT = "/v5/spot-margin-trade/repayment-available-amount"
+    GET_CURRENCY_DATA = "/v5/spot-margin-trade/currency-data"
 
     def __str__(self) -> str:
         return self.value

--- a/pybit/user.py
+++ b/pybit/user.py
@@ -18,6 +18,8 @@ class User(str, Enum):
     DELETE_SUB_UID = "/v5/user/del-submember"
     GET_ALL_SUB_API_KEYS = "/v5/user/sub-apikeys"
     GET_ESCROW_SUB_MEMBERS = "/v5/user/escrow_sub_members"
+    SIGN_AGREEMENT = "/v5/user/agreement"
+    GET_FRIEND_REFERRALS = "/v5/user/invitation/referrals"
 
     def __str__(self) -> str:
         return self.value


### PR DESCRIPTION
Breaking changes (from v5.14.0):
- Python v3.6 to 3.9 are no longer officially supported. They were not supposed to be supported in the first place (corresponding packages used break on 3.7 and below), but now the minimum supported version is **Python 3.10**
- Spread Trading endpoint names adjusted to prevent conflicts

New features and edits:
- V5 Account, Asset, Broker, New Crypto Loan, Asset ConvertFiat, Position, Spot Margin Trading, Spread Trading, User endpoints were brought up to date to match current feature set of Bybit API
- Fixed some bugs, such as 10006 on public endpoints
- Overall enhancement and optimization, refactoring in some spots