### PR TITLE
[RELEASE] pybit v5.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ In addition:
 - WebSocket `exit()` so that it cancels the scheduled custom ping and does not raise `WebSocketConnectionClosedException` after shutdown
 
 
-## [5.15.0rc2] - 2026-03-27
+## [5.15.0rc2] - 2026-03-18
 
 ### Added
 - Account HTTP endpoint `set_delta_mode()`
@@ -50,7 +50,7 @@ In addition:
 - Spread Trading HTTP endpoint names to be prefixed with `spread_`, to avoid clashing with the unified trading methods
 
 
-## [5.15.0rc1] - 2026-03-18
+## [5.15.0rc1] - 2026-03-14
 
 ### Changed
 - Dropped Python 3.6 to 3.9 support, as these versions have reached EOL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.15.0rc2] - 2026-03-27
+
+### Added
+- Account HTTP endpoint `set_delta_mode()`
+- Asset HTTP endpoints
+  - `get_asset_overview()`
+  - `get_funding_acc_history()`
+- Fiat convert HTTP endpoints
+  - `get_fiat_balance()`
+  - `get_fiat_trading_pair_list()`
+  - `get_fiat_convert_history()`
+  - `request_a_quote_fiat_convert()`
+  - `get_fiat_reference_price()`
+  - `confirm_a_quote_fiat_convert()`
+  - `get_fiat_convert_status()`
+- Broker HTTP endpoints
+  - `get_broker_all_rate_limits()`
+  - `get_broker_rate_limit_cap()`
+  - `set_broker_rate_limit()`
+- Crypto Loan HTTP endpoint `get_max_loan_amount_new_crypto_loan()`
+- Position HTTP endpoint `confirm_new_risk_limit()`
+- Spot Margin Trading HTTP endpoint `spot_margin_trade_get_currency_data()`
+- User HTTP endpoints
+  - `sign_agreement()`
+  - `get_friend_referrals()`
+
+### Changed
+- Account HTTP endpoint `set_no_convert_repay()` to `manual_no_convert_repay()`, to match the API's current semantics
+- Account HTTP endpoint `get_instruments_info()` to `get_account_instruments_info()`, to avoid ambiguity with other product groups
+- Account HTTP endpoint `set_hedging_mode()` so that its arg is `setHedgingMode` with values `ON` or `OFF`
+- Spread Trading HTTP endpoint names to be prefixed with `spread_`, to avoid clashing with the unified trading methods
+
+
+## [5.15.0rc1] - 2026-03-18
+
+### Changed
+- Dropped Python 3.6 to 3.9 support, as these versions have reached EOL
+- `pybit` now requires Python 3.10 or higher
+
+
 ## [5.14.0] - 2026-02-06
 
 Formally release changes from the pre-releases: 5.14.0rc0, 5.14.0rc1, 5.14.0rc2.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ In addition:
 - HTTP retry logic for retriable Bybit API errors, so that retryable `retCode`s now perform another request instead of raising `Exception: Retryable error occurred, retrying...`
 - HTTP retry logic for `retCode` `10002`, so that the expanded `recv_window` is carried into the next retry attempt
 - WebSocket `exit()` so that it cancels the scheduled custom ping and does not raise `WebSocketConnectionClosedException` after shutdown
+- WebSocket connect and exit loops so that they do not busy-wait on socket state changes
 
 
 ## [5.15.0rc2] - 2026-03-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.15.0] - 2026-03-27
+
+Formally release changes from the pre-releases: 5.15.0rc1, 5.15.0rc2.
+
+In addition:
+
+### Fixed
+- HTTP retry logic for retriable Bybit API errors, so that retryable `retCode`s now perform another request instead of raising `Exception: Retryable error occurred, retrying...`
+- HTTP retry logic for `retCode` `10002`, so that the expanded `recv_window` is carried into the next retry attempt
+- WebSocket `exit()` so that it cancels the scheduled custom ping and does not raise `WebSocketConnectionClosedException` after shutdown
+
+
 ## [5.15.0rc2] - 2026-03-27
 
 ### Added

--- a/pybit/__init__.py
+++ b/pybit/__init__.py
@@ -1,1 +1,1 @@
-VERSION = "5.15.0rc2"
+VERSION = "5.15.0"

--- a/pybit/_http_manager.py
+++ b/pybit/_http_manager.py
@@ -37,6 +37,12 @@ TLD_KZ = "kz"           # Kazakhstan
 TLD_EU = "eu"           # European Economic Area. ONLY AVAILABLE TO INSTITUTIONS
 
 
+class _RetryableRequestError(Exception):
+    def __init__(self, recv_window):
+        self.recv_window = recv_window
+        super().__init__("Retryable error occurred, retrying...")
+
+
 def generate_signature(use_rsa_authentication, secret, param_str):
     def generate_hmac():
         hash = hmac.new(
@@ -196,6 +202,9 @@ class _V5HTTPManager:
 
                 return self._handle_response(response, method, path, req_params, recv_window, retries_attempted)
 
+            except _RetryableRequestError as e:
+                recv_window = e.recv_window
+                continue
             except (requests.exceptions.ReadTimeout, requests.exceptions.SSLError,
                     requests.exceptions.ConnectionError) as e:
                 self._handle_network_error(e, retries_attempted)
@@ -275,8 +284,10 @@ class _V5HTTPManager:
             error_msg = f"{s_json[ret_msg]} (ErrCode: {error_code})"
 
             if error_code in self.retry_codes:
-                self._handle_retryable_error(response, error_code, error_msg, recv_window)
-                raise Exception("Retryable error occurred, retrying...")
+                recv_window = self._handle_retryable_error(
+                    response, error_code, error_msg, recv_window
+                )
+                raise _RetryableRequestError(recv_window)
 
             if error_code not in self.ignore_codes:
                 raise InvalidRequestError(
@@ -318,6 +329,7 @@ class _V5HTTPManager:
 
         self.logger.error(f"{error_msg}. Retrying...")
         time.sleep(delay_time)
+        return recv_window
 
     def _handle_network_error(self, error, retries_attempted):
         """Handle network-related exceptions."""

--- a/pybit/_websocket_stream.py
+++ b/pybit/_websocket_stream.py
@@ -71,6 +71,7 @@ class _WebSocketManager:
         self.ping_interval = ping_interval
         self.ping_timeout = ping_timeout
         self.custom_ping_message = json.dumps({"op": "ping"})
+        self.custom_ping_timer = None
         self.retries = retries
 
         # Other optional data handling settings.
@@ -258,14 +259,29 @@ class _WebSocketManager:
         self._send_custom_ping()
 
     def _send_custom_ping(self):
-        self.ws.send(self.custom_ping_message)
+        if self.exited or not self.is_connected():
+            return
+
+        try:
+            self.ws.send(self.custom_ping_message)
+        except websocket.WebSocketConnectionClosedException:
+            logger.debug(
+                f"WebSocket {self.ws_name} closed before custom ping could be sent."
+            )
 
     def _send_initial_ping(self):
         """https://github.com/bybit-exchange/pybit/issues/164"""
-        timer = threading.Timer(
+        self._stop_custom_ping_timer()
+        self.custom_ping_timer = threading.Timer(
             self.ping_interval, self._send_custom_ping
         )
-        timer.start()
+        self.custom_ping_timer.daemon = True
+        self.custom_ping_timer.start()
+
+    def _stop_custom_ping_timer(self):
+        if self.custom_ping_timer is not None:
+            self.custom_ping_timer.cancel()
+            self.custom_ping_timer = None
 
     @staticmethod
     def _is_custom_pong(message):
@@ -279,6 +295,7 @@ class _WebSocketManager:
         """
         Set state booleans and initialize dictionary.
         """
+        self._stop_custom_ping_timer()
         self.exited = False
         self.auth = False
         self.data = {}
@@ -287,11 +304,15 @@ class _WebSocketManager:
         """
         Closes the websocket connection.
         """
+        self.exited = True
+        self._stop_custom_ping_timer()
+
+        if not hasattr(self, "ws"):
+            return
 
         self.ws.close()
         while self.ws.sock:
             continue
-        self.exited = True
 
 
 class _V5WebSocketManager(_WebSocketManager):

--- a/pybit/_websocket_stream.py
+++ b/pybit/_websocket_stream.py
@@ -19,6 +19,7 @@ DEMO_SUBDOMAIN_MAINNET = "stream-demo"
 DOMAIN_MAIN = "bybit"
 DOMAIN_ALT = "bytick"
 TLD_MAIN = "com"
+SOCKET_WAIT_INTERVAL = 0.01
 
 
 class _WebSocketManager:
@@ -174,6 +175,7 @@ class _WebSocketManager:
             while self.wst.is_alive():
                 if self.ws.sock and self.is_connected():
                     break
+                time.sleep(SOCKET_WAIT_INTERVAL)
 
             # If connection was not successful, raise error.
             if not infinitely_reconnect and retries <= 0:
@@ -312,7 +314,7 @@ class _WebSocketManager:
 
         self.ws.close()
         while self.ws.sock:
-            continue
+            time.sleep(SOCKET_WAIT_INTERVAL)
 
 
 class _V5WebSocketManager(_WebSocketManager):

--- a/tests/test_pybit.py
+++ b/tests/test_pybit.py
@@ -4,6 +4,7 @@ import pytest
 import hmac
 import hashlib
 from collections import defaultdict
+from unittest.mock import Mock
 
 import requests
 import websocket
@@ -224,3 +225,93 @@ def test_send_custom_ping_skips_disconnected_socket():
     manager._send_custom_ping()
 
     assert manager.ws.sent_messages == []
+
+
+def test_submit_request_retries_when_retcode_is_retryable():
+    manager = _V5HTTPManager(api_key=_api_key, api_secret=_api_secret)
+    manager.retry_delay = 0
+
+    first_response = Mock()
+    first_response.status_code = 200
+    first_response.headers = {}
+    first_response.elapsed = 0
+    first_response.url = "https://api.bybit.com/v5/order/realtime"
+    first_response.json.return_value = {
+        "retCode": 10006,
+        "retMsg": "Too many visits",
+        "result": {},
+        "time": 1234567890,
+    }
+
+    second_response = Mock()
+    second_response.status_code = 200
+    second_response.headers = {}
+    second_response.elapsed = 0
+    second_response.url = "https://api.bybit.com/v5/order/realtime"
+    second_response.json.return_value = {
+        "retCode": 0,
+        "retMsg": "OK",
+        "result": {"list": []},
+        "time": 1234567891,
+    }
+
+    manager.client.send = Mock(side_effect=[first_response, second_response])
+
+    result = manager._submit_request(
+        method="GET",
+        path="https://api.bybit.com/v5/order/realtime",
+        query={"category": "linear"},
+        auth=True,
+    )
+
+    assert result["retCode"] == 0
+    assert manager.client.send.call_count == 2
+
+
+def test_submit_request_retries_with_expanded_recv_window_after_10002():
+    manager = _V5HTTPManager(api_key=_api_key, api_secret=_api_secret)
+    manager.retry_delay = 0
+
+    first_response = Mock()
+    first_response.status_code = 200
+    first_response.headers = {}
+    first_response.elapsed = 0
+    first_response.url = "https://api.bybit.com/v5/order/realtime"
+    first_response.json.return_value = {
+        "retCode": 10002,
+        "retMsg": "invalid request, please check your server timestamp or recv_window param",
+        "result": {},
+        "time": 1234567890,
+    }
+
+    second_response = Mock()
+    second_response.status_code = 200
+    second_response.headers = {}
+    second_response.elapsed = 0
+    second_response.url = "https://api.bybit.com/v5/order/realtime"
+    second_response.json.return_value = {
+        "retCode": 0,
+        "retMsg": "OK",
+        "result": {"list": []},
+        "time": 1234567891,
+    }
+
+    captured_recv_windows = []
+
+    def fake_prepare_headers(payload, recv_window):
+        captured_recv_windows.append(recv_window)
+        return {}
+
+    manager._prepare_headers = fake_prepare_headers
+    manager.client.send = Mock(side_effect=[first_response, second_response])
+
+    result = manager._submit_request(
+        method="GET",
+        path="https://api.bybit.com/v5/order/realtime",
+        query={"category": "linear"},
+        auth=True,
+    )
+
+    assert result["retCode"] == 0
+    assert manager.client.send.call_count == 2
+    assert captured_recv_windows == [5000, 7500]

--- a/tests/test_pybit.py
+++ b/tests/test_pybit.py
@@ -315,3 +315,39 @@ def test_submit_request_retries_with_expanded_recv_window_after_10002():
     assert result["retCode"] == 0
     assert manager.client.send.call_count == 2
     assert captured_recv_windows == [5000, 7500]
+
+
+def test_submit_request_returns_response_when_retcode_is_ignored():
+    manager = _V5HTTPManager(api_key=_api_key, api_secret=_api_secret)
+    manager.ignore_codes.add(110043)
+
+    ignored_response = Mock()
+    ignored_response.status_code = 200
+    ignored_response.headers = {}
+    ignored_response.elapsed = 0
+    ignored_response.url = "https://api-testnet.bybit.com/v5/position/set-leverage"
+    ignored_response.json.return_value = {
+        "retCode": 110043,
+        "retMsg": "leverage not changed",
+        "result": {},
+        "retExtInfo": {},
+        "time": 1234567890,
+    }
+
+    manager.client.send = Mock(return_value=ignored_response)
+
+    result = manager._submit_request(
+        method="POST",
+        path="https://api-testnet.bybit.com/v5/position/set-leverage",
+        query={
+            "category": "linear",
+            "symbol": "BTCUSDT",
+            "buyLeverage": "10",
+            "sellLeverage": "10",
+        },
+        auth=True,
+    )
+
+    assert result["retCode"] == 110043
+    assert result["retMsg"] == "leverage not changed"
+    assert manager.client.send.call_count == 1

--- a/tests/test_pybit.py
+++ b/tests/test_pybit.py
@@ -6,8 +6,10 @@ import hashlib
 from collections import defaultdict
 
 import requests
+import websocket
 
 from pybit._http_manager import _V5HTTPManager
+from pybit._websocket_stream import _WebSocketManager
 from pybit.unified_trading import HTTP
 from pybit import _http_manager
 
@@ -140,3 +142,85 @@ def test_logger_handler_attached():
     finally:
         # restore original handlers
         root.handlers = old_handlers
+
+
+class _FakeSock:
+    def __init__(self, connected=True):
+        self.connected = connected
+
+
+class _FakeWS:
+    def __init__(self, connected=True, send_error=None):
+        self.sock = _FakeSock(connected=connected)
+        self.send_error = send_error
+        self.sent_messages = []
+        self.closed = False
+
+    def send(self, message):
+        if self.send_error is not None:
+            raise self.send_error
+        self.sent_messages.append(message)
+
+    def close(self):
+        self.closed = True
+        self.sock = None
+
+
+class _FakeTimer:
+    def __init__(self):
+        self.daemon = False
+        self.started = False
+        self.cancelled = False
+
+    def start(self):
+        self.started = True
+
+    def cancel(self):
+        self.cancelled = True
+
+
+def test_websocket_exit_cancels_custom_ping_timer():
+    manager = _WebSocketManager(
+        lambda _: None,
+        "Test WS",
+        testnet=False,
+    )
+    manager.ws = _FakeWS()
+    timer = _FakeTimer()
+    manager.custom_ping_timer = timer
+
+    manager.exit()
+
+    assert manager.exited is True
+    assert timer.cancelled is True
+    assert manager.custom_ping_timer is None
+    assert manager.ws.closed is True
+
+
+def test_send_custom_ping_ignores_closed_connection():
+    manager = _WebSocketManager(
+        lambda _: None,
+        "Test WS",
+        testnet=False,
+    )
+    manager.ws = _FakeWS(
+        connected=True,
+        send_error=websocket.WebSocketConnectionClosedException(
+            "Connection is already closed."
+        ),
+    )
+
+    manager._send_custom_ping()
+
+
+def test_send_custom_ping_skips_disconnected_socket():
+    manager = _WebSocketManager(
+        lambda _: None,
+        "Test WS",
+        testnet=False,
+    )
+    manager.ws = _FakeWS(connected=False)
+
+    manager._send_custom_ping()
+
+    assert manager.ws.sent_messages == []

--- a/tests/test_pybit.py
+++ b/tests/test_pybit.py
@@ -227,6 +227,44 @@ def test_send_custom_ping_skips_disconnected_socket():
     assert manager.ws.sent_messages == []
 
 
+def test_websocket_exit_waits_with_sleep_until_socket_closes(monkeypatch):
+    manager = _WebSocketManager(
+        lambda _: None,
+        "Test WS",
+        testnet=False,
+    )
+
+    class _SlowCloseWS:
+        def __init__(self):
+            self._sock = object()
+            self.close_called = False
+
+        @property
+        def sock(self):
+            return self._sock
+
+        @sock.setter
+        def sock(self, value):
+            self._sock = value
+
+        def close(self):
+            self.close_called = True
+
+    manager.ws = _SlowCloseWS()
+    sleep_calls = []
+
+    def fake_sleep(delay):
+        sleep_calls.append(delay)
+        manager.ws.sock = None
+
+    monkeypatch.setattr("pybit._websocket_stream.time.sleep", fake_sleep)
+
+    manager.exit()
+
+    assert manager.ws.close_called is True
+    assert sleep_calls == [0.01]
+
+
 def test_submit_request_retries_when_retcode_is_retryable():
     manager = _V5HTTPManager(api_key=_api_key, api_secret=_api_secret)
     manager.retry_delay = 0


### PR DESCRIPTION
## [5.15.0] - 2026-03-27

Formally release changes from the pre-releases: 5.15.0rc1, 5.15.0rc2.

In addition:

### Fixed
- HTTP retry logic for retriable Bybit API errors, so that retryable `retCode`s now perform another request instead of raising `Exception: Retryable error occurred, retrying...`
- HTTP retry logic for `retCode` `10002`, so that the expanded `recv_window` is carried into the next retry attempt
- WebSocket `exit()` so that it cancels the scheduled custom ping and does not raise `WebSocketConnectionClosedException` after shutdown
- WebSocket connect and exit loops so that they do not busy-wait on socket state changes