### PR TITLE
ci: add GitHub Actions workflow for automated PyPI release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Build package
+        run: |
+          pip install --upgrade pip build
+          python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Triggered by pushing a v* tag. Builds sdist and wheel via `python -m build` (compatible with the existing setup.py) and publishes to PyPI using Trusted Publishing (OIDC, no long-lived token).

Prerequisites for this workflow to succeed after merge:
1. A PyPI Trusted Publisher must be configured on the pybit project pointing to bybit-exchange/pybit and workflow file publish.yml.
2. Optionally, a protected GitHub Environment named "pypi" can be added to gate releases behind maintainer approval.